### PR TITLE
Auto-detect collections

### DIFF
--- a/packages/msavin:mongol/client/Mongol/Mongol.js
+++ b/packages/msavin:mongol/client/Mongol/Mongol.js
@@ -1,21 +1,22 @@
 Template.Mongol.helpers({
     'Mongol_enabled': function () {
-        var Mongol = Session.get("Mongol");
-        return Mongol.display;
+        var MongolConfig = Session.get("Mongol");
+        return MongolConfig.display;
     },
     Mongol_collections: function () {
-        var Mongol = Session.get("Mongol");
-        return Mongol.collections;
+        var MongolConfig = Session.get("Mongol");
+        return MongolConfig.collections;
     },
     active: function () {
-        var Mongol = Session.get("Mongol_currentCollection")
-        if (Mongol != false && Mongol != null) {
+        var MongolCollection = Session.get("Mongol_currentCollection")
+        if (MongolCollection !== false && MongolCollection !== null) {
             return "Mongol_expand";
         }
     },
     Mongol_configured: function () {
-        var Mongol = Session.get("Mongol");
-        if (Mongol) {
+		// Note: Mongol will always be configured by default
+        var MongolConfig = Session.get("Mongol");
+        if (MongolConfig) {
             return true;
         }
     }
@@ -29,7 +30,7 @@ Template.Mongol.rendered = function () {
 
         // hot keys
         $(document).keydown(function(e) {
-            if (e.keyCode == 77 && e.ctrlKey) {
+            if (e.keyCode === 77 && e.ctrlKey) {
                MongolPackage.toggleDisplay();
             }
         });

--- a/packages/msavin:mongol/client/account/account.html
+++ b/packages/msavin:mongol/client/account/account.html
@@ -1,5 +1,5 @@
 <template name="Mongol_account">
-	<div class="Mongol_row {{active}}" id="Mongol_c{{this}}">
+	<div class="Mongol_row {{active}}" id="Mongol_c{{this}}" style="white-space:normal;">
 		
         <div class="Mongol_toggle_selected_collection">
         
@@ -22,11 +22,12 @@
 			<div class="Mongol_docMenu {{Mongol_docMenu_editing}}">
 					<div class="Mongol_docBar1" style="text-indent: 5px">
 						Not Signed In
+                        {{#if canSignIn}}<div class="Mongol_m_signin">Sign In</div>{{/if}}
 					</div>
 				</div>
 			<div class="Mongol_documentViewer">	
 				{{#if hasAccountsUI}}
-					{{> loginButtons}}
+					<!-- {{> loginButtons}} this is problematic, as the widget uses id="..." meaning it will mess with existing loginButtons -->
 				{{else}}
 <pre>Add Accounts UI to be able to
 to sign in from here.

--- a/packages/msavin:mongol/client/account/account.html
+++ b/packages/msavin:mongol/client/account/account.html
@@ -1,15 +1,19 @@
 <template name="Mongol_account">
 	<div class="Mongol_row {{active}}" id="Mongol_c{{this}}">
 		
-		<!-- Display sign in status -->
-		{{#if currentUser}}
-			<div class="Mongol_account_active"></div>
-		{{else}}
-			<div class="Mongol_account_inactive"></div>
-		{{/if}}
+        <div class="Mongol_toggle_selected_collection">
+        
+			<!-- Display sign in status -->
+			{{#if currentUser}}
+				<div class="Mongol_account_active"></div>
+			{{else}}
+				<div class="Mongol_account_inactive"></div>
+			{{/if}}
 
-		<!-- Name -->
-		Account
+			<!-- Name -->
+			Account
+        
+        </div>
 
 		<!-- Document Viewer -->
 		{{#if currentUser}}

--- a/packages/msavin:mongol/client/account/account.js
+++ b/packages/msavin:mongol/client/account/account.js
@@ -1,6 +1,6 @@
 Template.Mongol_account.helpers({
 	active: function () {
-		if (Session.get("Mongol_currentCollection") === "account_618") {
+		if (Session.equals("Mongol_currentCollection","account_618")) {
 			return "Mongol_row_expand"
 		}
 	},
@@ -14,7 +14,7 @@ Template.Mongol_account.helpers({
 
 Template.Mongol_account.events({
 	'click .Mongol_toggle_selected_collection': function () {
-		if (Session.get("Mongol_currentCollection")) {
+		if (Session.equals("Mongol_currentCollection", "account_618")) {
 		  Session.set("Mongol_currentCollection", null);
 		} else {
 		  Session.set("Mongol_currentCollection", "account_618");

--- a/packages/msavin:mongol/client/account/account.js
+++ b/packages/msavin:mongol/client/account/account.js
@@ -4,10 +4,15 @@ Template.Mongol_account.helpers({
 			return "Mongol_row_expand"
 		}
 	},
-	hasAccountsUI: function() {
+	hasAccountsUI: function () {
 		if (Template["loginButtons"]) {
 			return true;
 		}
+	},
+	canSignIn: function () {
+		// Not reactive, but it'll have to do
+		console.log("canSignIn",!Meteor.userId() && $('#login-sign-in-link').length);
+		return !Meteor.userId() && $('#login-sign-in-link').length;
 	}
 });
 
@@ -20,5 +25,7 @@ Template.Mongol_account.events({
 		  Session.set("Mongol_currentCollection", "account_618");
 		}
 	},
-}); 
-
+	'click .Mongol_m_signin': function () {
+		$('#login-sign-in-link').trigger('click');	
+	}
+});

--- a/packages/msavin:mongol/client/account/account.js
+++ b/packages/msavin:mongol/client/account/account.js
@@ -13,8 +13,12 @@ Template.Mongol_account.helpers({
 
 
 Template.Mongol_account.events({
-	'click .Mongol_row': function () {
-		Session.set("Mongol_currentCollection", "account_618")
+	'click .Mongol_toggle_selected_collection': function () {
+		if (Session.get("Mongol_currentCollection")) {
+		  Session.set("Mongol_currentCollection", null);
+		} else {
+		  Session.set("Mongol_currentCollection", "account_618");
+		}
 	},
 }); 
 

--- a/packages/msavin:mongol/client/account/accountViewer.js
+++ b/packages/msavin:mongol/client/account/accountViewer.js
@@ -24,6 +24,6 @@ Template.Mongol_accountViewer.helpers({
 	    
 	},
 	usercode: function () {
-		return Metero.userId()
+		return Meteor.userId()
 	},
 });

--- a/packages/msavin:mongol/client/collections/collections.html
+++ b/packages/msavin:mongol/client/collections/collections.html
@@ -1,14 +1,18 @@
 <template name="Mongol_collection">
 	<div class="Mongol_row {{active}}" id="Mongol_c{{this}}">
 		
-		<!-- Collection Count -->
-		<div class="Mongol_counter">
-			{{#if collectionCount}}
-			<span class="MongolHide">{{currentPosition}}/</span>{{/if}}{{collectionCount}}
-		</div>
-
-		<!-- Collection Name -->
-		{{this}}
+        <div class="Mongol_toggle_selected_collection">
+        
+			<!-- Collection Count -->
+			<div class="Mongol_counter">
+				{{#if collectionCount}}
+				<span class="MongolHide">{{currentPosition}}/</span>{{/if}}{{collectionCount}}
+			</div>
+	
+			<!-- Collection Name -->
+			{{this}}
+    	    
+        </div>
 
 		<!-- Document Viewer -->
 		{{> Mongol_docViewer}}

--- a/packages/msavin:mongol/client/collections/collections.js
+++ b/packages/msavin:mongol/client/collections/collections.js
@@ -1,46 +1,54 @@
 if (Meteor.isClient) {
 
 	Template.Mongol_collection.events({
-		'click': function () {
+		'click .Mongol_toggle_selected_collection': function (evt) {
 
-			var targetCollection =  String(this),
-				sessionKey       = "Mongol_" + targetCollection;		
-
-			if (targetCollection == Session.get("Mongol_currentCollection")) {
-				// do nothing
+			var targetCollection =  String(this);
+			var sessionKey       = "Mongol_" + targetCollection;
+				console.log(targetCollection,Session.get("Mongol_currentCollection"));
+			if (Session.equals("Mongol_currentCollection",targetCollection)) {
+				
+				// either do nothing or collapse the pane
+				// comment out the line below for not collapsing the pane
+				Session.set("Mongol_currentCollection",null);
+				
 			} else {
 				
 				Session.set("Mongol_editMode", false)
 
-				var thisCollection = window[targetCollection],
-					documentCount = thisCollection.find().count();
+				var thisCollection = Mongol.Collection(targetCollection);
+				var documentCount = thisCollection.find().count();
 
 				// If the collection doesn't have an index key set,
 				// start it from the first document
 				if (!Session.get(sessionKey)) {
 					Session.set(sessionKey, 0);
 				}
-			}
 
-			Session.set("Mongol_currentCollection", targetCollection);
+				Session.set("Mongol_currentCollection", targetCollection);
+				
+			}
 			
 		}
 	});
 
 	Template.Mongol_collection.helpers({
 		active: function () {
+			
 			var currentCollection = Session.get("Mongol_currentCollection"),
-				targetCollection  = this;
+				targetCollection  = String(this);
 
-			if (currentCollection == targetCollection) {
+			if (currentCollection === targetCollection) {
 				return "Mongol_row_expand";
 			} 
+			
 		},
 	    collectionCount: function () {
 
-	        var collectionName = this,
-	            collectionVar  = window[collectionName],
-	        	count          = collectionVar.find().count();
+	        var collectionName = String(this);
+	        var collectionVar  = Mongol.Collection(collectionName);
+				
+	        var count          = collectionVar && collectionVar.find().count() || 0;
 
 	        return count;
 
@@ -53,7 +61,8 @@ if (Meteor.isClient) {
 	        var current = Session.get(sessionKey);
 	        var count = current + 1;
 	        
-	        return count
+	        return count;
+			
 	    }
 	});
 

--- a/packages/msavin:mongol/client/collections/collections.js
+++ b/packages/msavin:mongol/client/collections/collections.js
@@ -5,7 +5,7 @@ if (Meteor.isClient) {
 
 			var targetCollection =  String(this);
 			var sessionKey       = "Mongol_" + targetCollection;
-				console.log(targetCollection,Session.get("Mongol_currentCollection"));
+			
 			if (Session.equals("Mongol_currentCollection",targetCollection)) {
 				
 				// either do nothing or collapse the pane

--- a/packages/msavin:mongol/client/defaults/defaults.js
+++ b/packages/msavin:mongol/client/defaults/defaults.js
@@ -1,0 +1,43 @@
+Meteor.startup(function() {
+	// If the user hasn't done a Session.set('Mongol',{ ... });
+	// set some default values
+
+	if (typeof Session.get('Mongol') === 'undefined') {
+	
+		// Build a default config object
+		
+		var collections = _.map(Mongo.Collection.getAll(),function(collection) {
+			
+			// Note this returns the actual mongo collection name, not Meteor's Mongo.Collection name
+			return collection.name;
+			 
+		});
+		
+		var defaults = {
+			'collections':    collections, 
+			'display':        false,
+			'opacity_normal': ".7",
+			'opacity_expand': ".9"
+		}
+	
+		Session.set("Mongol", defaults);
+	  
+	}
+  
+});
+
+
+// Give devs an api for hiding some collections, since they're all matched by default
+
+Mongol.hideCollection = function(collectionName) {
+
+	var MongolConfig = Session.get("Mongol") || {},
+		collections  = MongolConfig.collections || {};
+	
+	collections = _.without(collections, collectionName);
+	
+	MongolConfig.collections = collections;
+	
+	Session.set("Mongol", MongolConfig);
+	
+}

--- a/packages/msavin:mongol/client/docControls/docControls.html
+++ b/packages/msavin:mongol/client/docControls/docControls.html
@@ -13,14 +13,14 @@
 						<div class="Mongol_edit_save">Save</div>
 						<div class="Mongol_edit_cancel">Cancel</div>
 					{{else}}	
-						<!-- 
-							For some reason, the method in place does not work for this
-							Commenting out for now
-
-							<div class="Mongol_m_edit Mongol_m_updateAccount">Update</div>
-						 -->
-						&nbsp;Currently Read-Only
+						
+                        <!--For some reason, the method in place does not work for this
+                        Commenting out for now-->
+                        <div class="Mongol_m_edit Mongol_m_updateAccount">Update</div>
+						
+						<!-- &nbsp;Currently Read-Only -->
 						<div class="Mongol_m_signout">Sign Out</div>
+                        
 					{{/if}}
 				</div>
 			{{else}}

--- a/packages/msavin:mongol/client/docControls/docControls.js
+++ b/packages/msavin:mongol/client/docControls/docControls.js
@@ -4,21 +4,22 @@ Template.Mongol_docControls.events({
 	'click .Mongol_m_new': function () {
 
 		var CollectionName    = Session.get("Mongol_currentCollection"),
-			DocumentPosition  = Session.get("Mongol_" + this),
-			CurrentCollection = window[CollectionName].find().fetch(),
-			CollectionCount   = window[CollectionName].find().count(),
-			CurrentDocument   = CurrentCollection[DocumentPosition],
+			DocumentPosition  = Session.get("Mongol_" + String(this)),
+			CurrentCollection = Mongol.Collection(CollectionName).find().fetch(),
+			CollectionCount   = Mongol.Collection(CollectionName).find().count();
+			
+		var	CurrentDocument   = CurrentCollection[DocumentPosition],
 			DocumentID        = CurrentDocument._id,
-			sessionKey        = "Mongol_" + this;
+			sessionKey        = "Mongol_" + String(this);
 
 
 		Meteor.call("Mongol_duplicate", CollectionName, CurrentDocument, function (error, result) {
 			if (!error) {
 				
-				if (window[CollectionName].findOne(result)) {
+				if (Mongol.Collection(CollectionName).findOne(result)) {
 
 					// Get position of new document
-					var list  = window[CollectionName].find().fetch();
+					var list  = Mongol.Collection(CollectionName).find().fetch();
 					var docID = result;
 
 					docIndex = $.map(list, function(obj, index) {
@@ -44,11 +45,12 @@ Template.Mongol_docControls.events({
 	'click .Mongol_m_delete': function () {
 
 		var CollectionName    = Session.get("Mongol_currentCollection"),
-			sessionKey        = "Mongol_" + this;
+			sessionKey        = "Mongol_" + String(this);
 			DocumentPosition  = Session.get(sessionKey),
-			CurrentCollection = window[CollectionName].find().fetch(),
-			CollectionCount   = window[CollectionName].find().count(),
-			CurrentDocument   = CurrentCollection[DocumentPosition],
+			CurrentCollection = Mongol.Collection(CollectionName).find().fetch(),
+			CollectionCount   = Mongol.Collection(CollectionName).find().count();
+			
+		var	CurrentDocument   = CurrentCollection[DocumentPosition],
 			DocumentID        = CurrentDocument._id;
 
 			
@@ -85,12 +87,12 @@ Template.Mongol_docControls.events({
 		if (!$('.Mongol_m_right').hasClass('Mongol_m_disabled')) {
 			
 			// Grab the key
-			sessionKey        = "Mongol_" + this;
+			sessionKey          = "Mongol_" + String(this);
 
 			// Go forward one doc
-			var Mongol = Session.get(sessionKey) + 1;
-			Session.set(sessionKey, Mongol)
-			console.log("right" + this);
+			var MongolDocNumber = Session.get(sessionKey) + 1;
+			Session.set(sessionKey, MongolDocNumber);
+			// console.log("right" + this);
 		}
 	},
 	'click .Mongol_m_left': function () {
@@ -99,12 +101,12 @@ Template.Mongol_docControls.events({
 		if (!$('.Mongol_m_left').hasClass('Mongol_m_disabled')) {
 
 			// Grab the key
-			sessionKey        = "Mongol_" + this;
+			sessionKey          = "Mongol_" + String(this);
 
 			// Go back one doc
-			var Mongol = Session.get(sessionKey) - 1;
-			Session.set(sessionKey, Mongol)
-			console.log("left" + this);
+			var MongolDocNumber = Session.get(sessionKey) - 1;
+			Session.set(sessionKey, MongolDocNumber);
+			// console.log("left" + this);
 		}
 
 	},
@@ -114,12 +116,12 @@ Template.Mongol_docControls.events({
 			var targetCollection = "Meteor.users";
 			var newData   		 = MongolPackage.getDocumentUpdate("account_618");
 			var newObject 		 = MongolPackage.parse(newData);
-			console.log(targetCollection);
-			console.log(newData);
-			console.log(newObject);
+			// console.log(targetCollection);
+			// console.log(newData);
+			// console.log(newObject);
 		} else {
 			var targetCollection = String(this);
-			var newData   		 = MongolPackage.getDocumentUpdate(this);
+			var newData   		 = MongolPackage.getDocumentUpdate(String(this));
 			var newObject 		 = MongolPackage.parse(newData)
 		}
 
@@ -145,11 +147,12 @@ Template.Mongol_docControls.events({
 
 Template.Mongol_docControls.helpers({
 	disable_right: function () {
-		var sessionKey      = "Mongol_" + this,
-			CurrentDocument = Session.get(sessionKey),
-			collectionName  = this,
-		    collectionVar   = window[collectionName],
-			collectionCount = collectionVar.find().count() - 1;
+		var sessionKey      = "Mongol_" + String(this);
+		var CurrentDocument = Session.get(sessionKey);
+		var collectionName  = String(this);
+		var collectionVar   = Mongol.Collection(collectionName);
+			
+		var	collectionCount = collectionVar.find().count() - 1;
 
 		if (CurrentDocument === collectionCount) {
 			return "Mongol_m_disabled";
@@ -167,8 +170,8 @@ Template.Mongol_docControls.helpers({
 		}
 	},
 	disable_left: function () {		
-		sessionKey        = "Mongol_" + this;
-		CurrentDocument = Session.get(sessionKey);
+		var sessionKey        = "Mongol_" + String(this);
+		var CurrentDocument = Session.get(sessionKey);
 		
 		if (CurrentDocument <= 0) {
 			return "Mongol_m_disabled";
@@ -187,7 +190,7 @@ Template.Mongol_docControls.helpers({
 		
 		var current = Session.get("Mongol_currentCollection");
 		
-		// return true if collectoin name matches
+		// return true if collection name matches
 		if (current === String(this)) {
 			return true;
 		}

--- a/packages/msavin:mongol/client/docInsert/docInsert.js
+++ b/packages/msavin:mongol/client/docInsert/docInsert.js
@@ -2,9 +2,9 @@ Template.Mongol_docInsert.events({
 	'click .Mongol_docMenu_insert': function () {
 
 		var CollectionName = String(this),
-			newDataID      = "Mongol_" + this + "_newEntry",
-			newData        = document.getElementById(newDataID).textContent,
-			newObject      = MongolPackage.parse(newData);
+			newDataID      = "Mongol_" + String(this) + "_newEntry";
+		var newData        = document.getElementById(newDataID).textContent;
+		var newObject      = MongolPackage.parse(newData);
 
 		if (newObject) {
 			Meteor.call('Mongol_insert', CollectionName, newObject, function (error, result) {

--- a/packages/msavin:mongol/client/docViewer/docViewer.html
+++ b/packages/msavin:mongol/client/docViewer/docViewer.html
@@ -1,14 +1,14 @@
 <template name="Mongol_docViewer">
 
-	{{#if active}}
+	{{#if notEmpty}}
 		{{> Mongol_docControls}}
-		{{#if documentJSON}}
+		{{#with activeDocument}}
 			{{#if editStyle}}
-				<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{this}}" contenteditable="{{editContent}}">	
+				<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{..}}" contenteditable="{{editContent}}">	
 					<pre>{{{documentJSON}}}</pre>
 				</div>
 			{{else}}
-				<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{this}}" contenteditable="{{editContent}}">	
+				<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{..}}" contenteditable="{{editContent}}">	
 					<pre>{{{documentJSON}}}</pre>
 				</div>
 			{{/if}}
@@ -16,7 +16,7 @@
 			<div class="Mongol_documentViewer" id="MongolDoc_{{this}}">	
 				<pre>No document found</pre>
 			</div>
-		{{/if}}
+		{{/with}}
 	{{else}}
 		{{> Mongol_docInsert}}
 	{{/if}}

--- a/packages/msavin:mongol/client/docViewer/docViewer.html
+++ b/packages/msavin:mongol/client/docViewer/docViewer.html
@@ -4,13 +4,13 @@
 		{{> Mongol_docControls}}
 		{{#if documentJSON}}
 			{{#if editStyle}}
-			<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{this}}" contenteditable="{{editContent}}">	
-				<pre>{{{documentJSON}}}</pre>
-			</div>
+				<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{this}}" contenteditable="{{editContent}}">	
+					<pre>{{{documentJSON}}}</pre>
+				</div>
 			{{else}}
-			<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{this}}" contenteditable="{{editContent}}">	
-				<pre>{{{documentJSON}}}</pre>
-			</div>
+				<div class="Mongol_documentViewer {{editStyle}}" id="MongolDoc_{{this}}" contenteditable="{{editContent}}">	
+					<pre>{{{documentJSON}}}</pre>
+				</div>
 			{{/if}}
 		{{else}}
 			<div class="Mongol_documentViewer" id="MongolDoc_{{this}}">	

--- a/packages/msavin:mongol/client/docViewer/docViewer.js
+++ b/packages/msavin:mongol/client/docViewer/docViewer.js
@@ -3,12 +3,13 @@ if (Meteor.isClient) {
     Template.Mongol_docViewer.helpers({
         documentJSON: function () {
             
-            var currentCollection = window[this],
-                documents   = currentCollection.find().fetch(),
-                sessionKey  = "Mongol_" + this;
-                docNumber   = Session.get(sessionKey),
-                docCurrent  = documents[docNumber],
-                json_output = JSON.stringify(docCurrent, null, 2);
+			var collectionName    = String(this);
+            var currentCollection = Mongol.Collection(collectionName);
+			var documents         = currentCollection.find().fetch();
+            var sessionKey  = "Mongol_" + String(this);
+            var docNumber   = Session.get(sessionKey);
+            var docCurrent  = documents[docNumber];
+            var json_output = JSON.stringify(docCurrent, null, 2);
                 
                 if (! (typeof json_output === "undefined")) {
                     colorize    = MongolPackage.colorize(json_output);
@@ -24,7 +25,7 @@ if (Meteor.isClient) {
             var editMode = Session.get("Mongol_editMode");
             
             if (editMode) {
-                return "true"
+                return "true";
             }
 
         },
@@ -33,14 +34,14 @@ if (Meteor.isClient) {
             var editMode = Session.get("Mongol_editMode");
             
             if (editMode) {
-                return "Mongol_editable"
+                return "Mongol_editable";
             }
             
         },
         active: function() {
-            documentCount = window[this].find().count()
+            documentCount = Mongol.Collection(String(this)) && Mongol.Collection(String(this)).find().count()
             if (documentCount >= 1) {
-                return true
+                return true;
             }
         }
     });

--- a/packages/msavin:mongol/client/docViewer/docViewer.js
+++ b/packages/msavin:mongol/client/docViewer/docViewer.js
@@ -1,14 +1,17 @@
 if (Meteor.isClient) {
 
     Template.Mongol_docViewer.helpers({
-        documentJSON: function () {
-            
+        activeDocument: function () {
 			var collectionName    = String(this);
             var currentCollection = Mongol.Collection(collectionName);
 			var documents         = currentCollection.find().fetch();
             var sessionKey  = "Mongol_" + String(this);
             var docNumber   = Session.get(sessionKey);
             var docCurrent  = documents[docNumber];
+			return docCurrent;
+		},
+        documentJSON: function () {
+			var docCurrent = this;
             var json_output = JSON.stringify(docCurrent, null, 2);
                 
                 if (! (typeof json_output === "undefined")) {
@@ -38,8 +41,8 @@ if (Meteor.isClient) {
             }
             
         },
-        active: function() {
-            documentCount = Mongol.Collection(String(this)) && Mongol.Collection(String(this)).find().count()
+        notEmpty: function() {
+            documentCount = Mongol.Collection(String(this)) && Mongol.Collection(String(this)).find().count();
             if (documentCount >= 1) {
                 return true;
             }

--- a/packages/msavin:mongol/client/header/header.js
+++ b/packages/msavin:mongol/client/header/header.js
@@ -1,15 +1,15 @@
 Template.Mongol_header.events({
 	'click': function () {
-		Session.set("Mongol_currentCollection", "mongol_618")
+		Session.set("Mongol_currentCollection", "mongol_618");
 	},
 	'click .Mongol_Minimize': function () {
-		Session.set("Mongol_currentCollection")
+		Session.set("Mongol_currentCollection",null);
 	}
 });
 
 Template.Mongol_header.helpers({
 	active: function () {
-		if (Session.get("Mongol_currentCollection") === "mongol_618") {
+		if (Session.equals("Mongol_currentCollection", "mongol_618")) {
 			return "Mongol_row_expand"
 		}
 	},

--- a/packages/msavin:mongol/client/style/Mongol.css
+++ b/packages/msavin:mongol/client/style/Mongol.css
@@ -53,6 +53,9 @@
   text-indent: 6px;
   margin-top: 3px; }
 
+#Mongol a {
+  color: #999; }
+
 #Mongol * {
   outline: none; }
 #Mongol pre {
@@ -169,6 +172,7 @@
     margin: 0px;
     padding: 0px;
     padding-top: 3px;
+	color: #ccc;
     -webkit-touch-callout: text;
     -webkit-user-select: text;
     -khtml-user-select: text;

--- a/packages/msavin:mongol/client/style/Mongol.css
+++ b/packages/msavin:mongol/client/style/Mongol.css
@@ -264,7 +264,7 @@
   padding: 0 9px !important;
   background: #363636; }
 
-.Mongol_m_signout {
+.Mongol_m_signout, .Mongol_m_signin {
   border-left: 1px solid #232323;
   background: #363636;
   float: right;
@@ -273,7 +273,7 @@
 .Mongol_m_updateAccount {
   border-right: 1px solid #232323; }
 
-.Mongol_edit_save:hover, .Mongol_edit_cancel:hover, .Mongol_docMenu_insert:hover, .Mongol_m_signout:hover, .Mongol_m_left:hover, .Mongol_m_right:hover, .Mongol_m_new:hover, .Mongol_m_edit:hover, .Mongol_m_delete:hover {
+.Mongol_edit_save:hover, .Mongol_edit_cancel:hover, .Mongol_docMenu_insert:hover, .Mongol_m_signout:hover, .Mongol_m_signin:hover, .Mongol_m_left:hover, .Mongol_m_right:hover, .Mongol_m_new:hover, .Mongol_m_edit:hover, .Mongol_m_delete:hover {
   background: #4A4A4A;
   cursor: pointer; }
 

--- a/packages/msavin:mongol/common/common.js
+++ b/packages/msavin:mongol/common/common.js
@@ -1,0 +1,67 @@
+if (typeof Mongol === 'undefined') {
+
+	// Reserve this variable name across the package
+	// In case we'd like to export it to give package users a simple api
+	// e.g. when all collections have been matched by default, but the developer wants to suppress some
+	// Mongol.hideCollection('posts');
+	// Downside is that it pollutes the global namespace with `Mongol`, but most apps can probably live with that
+	// See /client/defaults/defaults.js for implementation
+	
+	Mongol = {};
+	
+}
+
+// Go through a variety of means of trying to return the correct collection
+
+Mongol.Collection = function(collectionName) {
+	
+	return	Mongo.Collection.get(collectionName)
+			// This should automatically match all collections by default
+			// including namespaced collections
+			
+		||	((Meteor.isServer) ? eval(collectionName) : drillDown(window,collectionName))
+			// For user defined collection names 
+			// in the form of Meteor's Mongo.Collection names as strings
+			
+		||	((Meteor.isServer) ? eval(firstToUpper(collectionName)) : drillDown(window,firstToUpper(collectionName)))
+			// For user defined collections where the user has typical upper-case collection names
+			// but they've put actual mongodb collection names into the Mongol config instead of Meteor's Mongo.Collection names as strings
+	
+		||	null;
+			// If the user has gone for unconventional casing of collection names,
+			// they'll have to get them right (i.e. Meteor's Mongo.Collection names as string) in the Mongol config manually
+	
+	
+	// Changes the first character of a string to upper case
+	
+	function firstToUpper(text) {
+	
+		return text.charAt(0).toUpperCase() + text.substr(1);
+		
+	}
+	
+	// This utility function takes a javascript object (`obj`)
+	// And a key for that object as a dot-delimited string (`key`)
+	// e.g. 
+	// var obj = { person : { name : "Jack", address : "Beijing, China"}};
+	// drillDown(obj,"person.name")
+	// => "Jack"
+	
+	function drillDown(obj,key) {
+		var pieces = key.split('.');
+		if (pieces.length > 1) {
+			var newObj = obj ? obj[pieces[0]] : {};
+			pieces.shift();
+			return drillDown(newObj,pieces.join('.'));
+		}
+		else {
+			if (obj) {
+				return obj[key];
+			}
+			else {
+				return; // undefined    
+			}    
+		}
+	}
+	
+}

--- a/packages/msavin:mongol/package.js
+++ b/packages/msavin:mongol/package.js
@@ -37,7 +37,8 @@ Package.onUse(function(api) {
   ];
 
   var serverFiles = [
-    "server/methods.js"
+    "server/methods.js",
+	"server/utility_functions.js"
   ];
   
   var commonFiles = [
@@ -52,7 +53,7 @@ Package.onUse(function(api) {
   api.add_files(serverFiles, "server");
   
   if (api.export) {
-    api.export('Mongol');
+    api.export('Mongol', "client");
   }
 
 });

--- a/packages/msavin:mongol/package.js
+++ b/packages/msavin:mongol/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name:    'msavin:mongol',
   summary: 'The insanely handy development package for Meteor.',
-  version: '0.3.5',
+  version: '0.4.0',
   git:     'https://github.com/msavin/Mongol.git',
   documentation: 'README.md',
   debugOnly: true
@@ -33,15 +33,26 @@ Package.onUse(function(api) {
     "client/docControls/docControls.js",
     "client/welcome/welcome.html",
     "client/welcome/welcome.js",
+	"client/defaults/defaults.js"
   ];
 
   var serverFiles = [
     "server/methods.js"
-  ]
+  ];
+  
+  var commonFiles = [
+    "common/common.js"
+  ];
 
   api.versionsFrom('1.0');
   api.use(['templating','tracker','mongo'], 'client');
+  api.use(['dburles:mongo-collection-instances@0.3.1']);
+  api.add_files(commonFiles);
   api.add_files(clientFiles, "client");
   api.add_files(serverFiles, "server");
+  
+  if (api.export) {
+    api.export('Mongol');
+  }
 
 });

--- a/packages/msavin:mongol/server/methods.js
+++ b/packages/msavin:mongol/server/methods.js
@@ -17,7 +17,7 @@ Meteor.methods({
 			return false;
 		}
 	},
-	Mongol_update: function(collectionName, documentData) { console.log(collectionName);
+	Mongol_update: function(collectionName, documentData, originalDocumentData) {
 		
 		// var task = function () {
 			// Convert Collection String to Variable
@@ -29,13 +29,17 @@ Meteor.methods({
 			// Strip the ID from the document
 			// to prepare it for update 
 			delete documentData._id;
+			delete originalDocumentData._id;
+			
+			var currentDbDoc = MongolCollection.findOne({_id: documentID});
+			var updatedDocumentData = Mongol.diffDocumentData(currentDbDoc, documentData, originalDocumentData);
 
 			// Run the magic
 			MongolCollection.update(
 				{
 					_id: documentID
 				}, 
-					documentData
+					updatedDocumentData
 				);
 		// }
 		

--- a/packages/msavin:mongol/server/methods.js
+++ b/packages/msavin:mongol/server/methods.js
@@ -17,11 +17,11 @@ Meteor.methods({
 			return false;
 		}
 	},
-	Mongol_update: function(collectionName, documentData) {
+	Mongol_update: function(collectionName, documentData) { console.log(collectionName);
 		
 		// var task = function () {
 			// Convert Collection String to Variable
-			var Mongol = eval(collectionName);
+			var MongolCollection = Mongol.Collection(collectionName);
 
 			// Get the document id
 			var documentID    = documentData._id; 
@@ -31,7 +31,7 @@ Meteor.methods({
 			delete documentData._id;
 
 			// Run the magic
-			Mongol.update(
+			MongolCollection.update(
 				{
 					_id: documentID
 				}, 
@@ -53,10 +53,10 @@ Meteor.methods({
 		// var task = function () {
 
 			// Convert Collection String to Variable
-			var Mongol = eval(collectionName);
+			var MongolCollection = Mongol.Collection(collectionName);
 
 			// Remove the document
-			Mongol.remove(documentID);
+			MongolCollection.remove(documentID);
 
 		// }
 
@@ -73,17 +73,17 @@ Meteor.methods({
 	Mongol_duplicate: function(collectionName, documentID) {
 		// var task = function () {
 			// Convert Collection String to Variable
-			var Mongol = eval(collectionName);
+			var MongolCollection = Mongol.Collection(collectionName);
 
 			// Get the document id
-			var OriginalDoc    = Mongol.findOne(documentID); 
+			var OriginalDoc    = MongolCollection.findOne(documentID); 
 
 			// Strip the ID from the document
 			// to prepare it for update 
 			delete OriginalDoc._id;
 
 			// Run the magic
-			var NewDocument = Mongol.insert(OriginalDoc);
+			var NewDocument = MongolCollection.insert(OriginalDoc);
 
 			// Return the ID
 			return NewDocument;
@@ -102,10 +102,10 @@ Meteor.methods({
 		
 		// var task = function () {
 			// Convert Collection String to Variable
-			var Mongol = eval(collectionName); 
+			var MongolCollection = Mongol.Collection(collectionName);
 
 			// Run the magic
-			Mongol.insert(documentData);
+			MongolCollection.insert(documentData);
 		// }
 
 		// Meteor.call("Mongol_verify", function (error, result) {

--- a/packages/msavin:mongol/server/utility_functions.js
+++ b/packages/msavin:mongol/server/utility_functions.js
@@ -1,0 +1,106 @@
+// This function takes three data points into account:
+
+// 1) the actual document as it stands on the server, prior to being updated
+// 2) the oldData that was on the client before the user pressed save
+// 3) the newData that the client is trying to save
+
+// This function decides which fields it is going to make writes to on this basis:
+// 1) The field(s) being overwritten must appear in the db doc and on the client oldData 
+//    (if they only appear in the oldData these must have been added dynamically on the client
+//     and we don't want to save these fields to the db)
+//    -- this includes fields that are being removed (i.e. they must appear in the db doc and the oldData)
+// 2) Only fields that appear in the newData, but not the oldData or db doc can be added
+//    (if it appears in the db doc, throw an error that says:
+//     "There is an unpublished field in the database with that name. Update cannot be made.")
+
+// The ramifications of all this:
+// You can only update/remove fields that are published
+// You can only add new fields if they don't exist in the db already
+
+
+Mongol.diffDocumentData = function(dbDoc, newData, oldData) {
+	
+	// TODO -- recurse into subdocuments, performing checks
+	// using the drillDown utility function (as seen in /common/common.js)
+
+	var finalData = {};
+	
+	var dbDocFields    = _.keys(dbDoc),
+	    newDataFields  = _.keys(newData), 
+		oldDataFields  = _.keys(oldData); // console.log("dbDocFields",dbDocFields); console.log("newDataFields",newDataFields); console.log("oldDataFields",oldDataFields);
+	
+	// First get the set of fields that we won't be saving because they were dynamically added on the client
+	
+	var dynamicallyAddedFields = _.difference(oldDataFields, dbDocFields);
+	
+	// The get the fields that must retain their dbDoc field value, because they we'ren't published
+	
+	var unpublishedFields = _.difference(dbDocFields, oldDataFields); // console.log("unpublishedFields",unpublishedFields);
+	
+	// iterate over all fields, old and new, and ascertain the field value that must be added to the final data object
+	
+	var oldAndNewFields = _.union(dbDocFields, newDataFields);
+	
+	_.each(oldAndNewFields, function (field) {
+		
+		if (_.contains(dynamicallyAddedFields,field)) {
+		  
+		 	// We don't want to add this field to the actual mongodb document
+			console.log("'" + field + "' appears to be a dynamically added field. This field was not updated.");
+			return;
+		  	
+		}
+		
+		if (_.contains(unpublishedFields, field)) {
+		
+		    // We don't want to overwrite the existing mondodb document value
+			if (newData[field]) {
+				// Give a message to user as to why that field wasn't updated
+				console.log("'" + field + "' is an unpublished field. This field's value was not overwritten.");
+			}
+			// Make sure the old value is retained
+			finalData[field] = dbDoc[field];
+			return;
+			
+		}
+		
+		finalData[field] = newData[field];
+		
+		// This will let unpublished fields into the database,
+		// so the user may be confused by the lack of an update in the client
+		// simply because the added field isn't published
+		// The following solves that problem, but doesn't allow new fields to be published at all:
+		//     finalData[field] = oldData[field] && newData[field];
+		// We actually need to know the set of fields published by the publication that the client side doc came from
+		// but how do we get that?
+		
+	});
+	
+	return finalData;
+
+}
+
+// Test code for Mongol.diffDocumentData
+
+/*Meteor.startup(function() {
+  
+  // Take a user document
+  var sampleDbDoc = { "_id" : "exampleuser1", "createdAt" : 1375253926213, "defaultPrograms" : { "514d75dc97d9562095578800" : "MYP", "515be9e6a57068c708000000" : "PYP" }, "department_id" : [  "GMsv9YzaCuL6dFBYL" ], "emails" : [  {  "address" : "babrahams@wab.edu",  "verified" : true } ], "myCourses" : [  "QqofG3XyEtQPgFb72",  "fvTxhAyfMxFbhzwK7",  "jcPtgwN2t6pTMQDEp" ], "organization_id" : [  "51f76bcb45623dfb1e0d3100" ], "permContexts" : [ 	{ 	"department_id" : "GMsv9YzaCuL6dFBYL", "perms" : [ 	"editRoles", 	"editCourses", 	"editUnits", 	"editAssessments", 	"editDepartments" ] } ], "roleContexts" : [ 	{ 	"organization_id" : "51f76bcb45623dfb1e0d3100", 	"school_id" : "514d75dc97d9562095578800", 	"department_id" : "GMsv9YzaCuL6dFBYL", 	"roles" : [ 	"iQD4BhnB8PFWwHCcg" ] }, 	{ 	"organization_id" : "2BjJbMyRLWa4iofQm" } ], "school_id" : [  "514d75dc97d9562095578800" ], "services" : { "password" : { "bcrypt" : "$2a$10$M55xiZA6rX0EwZ6xBk3Rre6/J5s3XUunre5.5ijyU3.ilpYZQFmtO" }, "resume" : { "loginTokens" : [ 	{ 	"when" : "2014-12-24T12:00:06.725Z", 	"hashedToken" : "not/telling=" }, 	{ 	"when" : "2015-01-16T04:45:10.574Z", 	"hashedToken" : "bigbadhashedtoken=" }, 	{ 	"when" : "2015-01-22T02:01:57.671Z", 	"hashedToken" : "9HSCRUygOiPYgmUsmWA5jcYutqKnjT9OByHPA6LbBB8=" } ] } }, "superuser" : [  "51f76bcb45623dfb1e0d3100",  "2BjJbMyRLWa4iofQm",  "ZkeRkDEEcp72bAFQY" ], "transaction_id" : "shQ9fzcZYSgLLnptC" };
+  
+  // Simulate the oldData getting sent back from the client (the fields should be a subset of the db fields)
+  var sampleOldData = _.extend(_.clone(sampleDbDoc),{dynamicallyAddedField:true, secondDynamicallyAddedField: "Dynamically added value"}); // Simulate two dynamically added fields
+  delete sampleOldData.services; // Simulate an unpublished field
+  
+  // Simulate the newData getting sent back from the client
+  // e.g. user adds a new field
+  var sampleNewData = _.extend(_.clone(sampleOldData),{brandNewField: true});
+  // brandNewField should be added
+  delete sampleNewData.createdAt; // This should be gone
+  sampleNewData.secondDynamicallyAddedField = "Dynamically added value overwritten by user"; // seconddynamicallyAddedField should be gone
+  sampleNewData.transaction_id = "overwritten transaction id"; // This field should be changed
+  
+  // Run the test
+  
+  console.log(Mongol.diffDocumentData(sampleDbDoc, sampleNewData, sampleOldData));
+  
+});*/


### PR DESCRIPTION
Sorry, man -- this is a pretty big pull request, but I think everything's working with auto-detected collections.  I've tested against one of my apps, but it could do with another run against someone else's app.

Namespaced collections are working.

Actual Meteor Mongo.Collection names are not displayed in the list anymore, the mongodb collection names are now, which arguably isn't as pretty (not capitalized), but possibly more representative of what's actually getting changed (i.e. actual mongodb collections).

Should all be non-breaking for all existing devs with configs set via Session.  They should see no difference when using the updated version.

I also threw in a few minor bugfixes and added a couple of lines of css to stop app css from bleeding into Mongol's design.  I should have separated this out into a bunch of separate commits, I know.  Sorry, it's all just one big-ass commit.
