### PR TITLE
Changed body.created hook to Meteor.startup to avoid fighting with other...

### DIFF
--- a/packages/msavin:mongol/client/Mongol/body.js
+++ b/packages/msavin:mongol/client/Mongol/body.js
@@ -1,6 +1,13 @@
-// Note `rendered` fails in some situations, use `created`
+//
+//  Re-Note: `rendered`, `created`, `destroyed` should not be used on body, window, or document.
+//  Essentially not on `unique` items which can have the values you just set overwritten by the
+//  next package that is loaded.
+//
+//  For a 'when ready' hook use 'Meteor.startup' called when the DOM is ready
+//  http://docs.meteor.com/#/full/meteor_startup
+//
 
-Template.body.created = function () {
+Meteor.startup(function(){
 
   // Set Mongol to Display
   // When User Clicks Controls + M
@@ -15,7 +22,7 @@ Template.body.created = function () {
 
   MongolPackage.startup();
 
-};
+});
 
 // Below is a working alternative to Template.body.created
 // Past experience says that adding this package as a


### PR DESCRIPTION
I spent a bunch of hours with my head in Meteor today all starting with this ctrl-M issue: https://github.com/msavin/Mongol/issues/20

I return with 1 small fix and a good deal more understanding. 

Bottom line: moving from 'Template.body.rendered' to 'Template.body.created' only moved the problem. 
Any package which comes along now and sets '.created' after you ( but before rendering ) will break it again. 

Instead use 'Meteor.startup' - note you don't have to overwrite a property to use it. So no turf wars.

Here's a tiny package, awelles:hook-test, which hooks "rendered", "created", and "destroyed" on 'Template.body':
https://github.com/awelles/awelles-hook-test

Steps:
1. Add awelles:hook-test to the current Mongol
2. Note the breakage of ctrl-M
3. Merge this pull request
4. Be whole once more
