### PR TITLE
Removing direct calls to $

### DIFF
--- a/client/doc_controls/docControls.js
+++ b/client/doc_controls/docControls.js
@@ -49,7 +49,7 @@ Template.Mongol_docControls.events({
           var list = Mongol.Collection(CollectionName).find({}, {transform: null}).fetch();
           var docID = result;
 
-          docIndex = $.map(list, function(obj, index) {
+          docIndex = _.map(list, function(obj, index) {
             if (obj._id == docID) {
               return index;
             }
@@ -109,9 +109,9 @@ Template.Mongol_docControls.events({
 
 
   },
-  'click .Mongol_m_right': function() {
+  'click .Mongol_m_right': function(e,t) {
     // Verify that the button is not disabled
-    if (!$('.Mongol_m_right').hasClass('Mongol_m_disabled')) {
+    if (!t.$('.Mongol_m_right').hasClass('Mongol_m_disabled')) {
       
       // Disable inline editing for 0.3s for quick flick to next doc
       Mongol.resetInlineEditingTimer();
@@ -140,10 +140,10 @@ Template.Mongol_docControls.events({
       
     }
   },
-  'click .Mongol_m_left': function() {
+  'click .Mongol_m_left': function(e,t) {
 
     // Verify that the button is not disabled
-    if (!$('.Mongol_m_left').hasClass('Mongol_m_disabled')) {
+    if (!t.$('.Mongol_m_left').hasClass('Mongol_m_disabled')) {
 
       // Disable inline editing for 0.3s for quick flick to next doc
       Mongol.resetInlineEditingTimer();


### PR DESCRIPTION
Please do not call directly jquery with $. 
Jquery is not loaded in the client by meteor before everything else... 

These $ calls caused the following error in my app:
Uncaught TypeError: $ is not a functionTemplate.Mongol_docControls.events.click .Mongol_m_right @ docControls.js:114(anonymous function) @ template.js:463Template._withTemplateInstanceFunc @ template.js:437

Jquery is officially available only in Template instances through TemplateInstance.$

I also fixed someplace where you used $.map. 
Same thing, jquery in meteor for utility calls is not wise. 
As Underscore.js is available in all your Meteor app, it is better to use _.map.

I have not looked elsewhere in your app, but i am pretty sure this pattern can cause other bugs !

I have not directly tested if my fixes break the app, but it should be fine i believe.

Best.
