### PR TITLE
Added 'check' package dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -46,6 +46,7 @@ Package.onUse(function(api) {
 
   api.versionsFrom('1.0');
 
+  api.use(‘check’);
   api.use(['templating','tracker','mongo'], 'client');
   
   // This must go before: api.use('dburles:mongo-collection-instances@0.3.1');


### PR DESCRIPTION
It fixes the following exception that happens on Meteor 1.2+:

```
I20150908-18:53:48.390(-3)? Exception from sub MeteorToys id pQi2BmA4eAWaiL6dd ReferenceError: Match is not defined
I20150908-18:53:48.391(-3)?     at [object Object]._0x3f8a [as _handler] (packages/meteortoys_toykit/packages/meteortoys_toykit.js:9:1)
I20150908-18:53:48.392(-3)?     at maybeAuditArgumentChecks (livedata_server.js:1692:12)
I20150908-18:53:48.392(-3)?     at [object Object]._.extend._runHandler (livedata_server.js:1023:17)
I20150908-18:53:48.392(-3)?     at [object Object]._.extend._startSubscription (livedata_server.js:842:9)
I20150908-18:53:48.392(-3)?     at [object Object]._.extend.protocol_handlers.sub (livedata_server.js:614:12)
I20150908-18:53:48.392(-3)?     at livedata_server.js:548:43
```
